### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ thumb16 thumb32 arm32 inlineHook
 
 # Example
 ```C
-#include <stdio.h>
+# include <stdio.h>
 
-#include "inlineHook.h"
+# include "inlineHook.h"
 
 int (*old_puts)(const char *) = NULL;
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
