### PR TITLE
修复 Thumb16 跳转崩溃问题

### DIFF
--- a/relocate.c
+++ b/relocate.c
@@ -196,7 +196,7 @@ static int relocateInstructionInThumb16(uint32_t pc, uint16_t instruction, uint1
 		else if (type == BX_THUMB16) {
 			value = pc;
 		}
-		
+		value |= 1; // thumb		
 		trampoline_instructions[idx++] = 0xF8DF;
 		trampoline_instructions[idx++] = 0xF000;	// LDR.W PC, [PC]
 		trampoline_instructions[idx++] = value & 0xFFFF;

--- a/relocate.c
+++ b/relocate.c
@@ -376,12 +376,16 @@ static int relocateInstructionInThumb32(uint32_t pc, uint16_t high_instruction, 
 			
 			value = addr[0];
 		}
-		
-		trampoline_instructions[0] = 0x4800 | (r << 8);	// LDR Rr, [PC]
-		trampoline_instructions[1] = 0xE001;	// B PC, #2
-		trampoline_instructions[2] = value & 0xFFFF;
-		trampoline_instructions[3] = value >> 16;
-		offset = 4;
+
+		// LDR.W Rr, [PC, 2]
+		trampoline_instructions[0] = 0xF8DF;
+		trampoline_instructions[1] = r << 12 | 4;
+
+		trampoline_instructions[2] = 0xBF00;     // nop
+		trampoline_instructions[3] = 0xE001;	// B PC, #2
+		trampoline_instructions[4] = value & 0xFFFF;
+		trampoline_instructions[5] = value >> 16;
+		offset = 6;
 	}
 
 	else if (type == TBB_THUMB32 || type == TBH_THUMB32) {


### PR DESCRIPTION
16位 thumb 跳转指令的目标地址是偶数, 导致 运行时 sigill
```
if (type == B1_THUMB16) {
      x = (instruction & 0xFF) << 1; // 此处 x 最低位是 0
      top_bit = x >> 8;
      imm32 = top_bit ? (x | (0xFFFFFFFF << 8)) : x; // imm32 最低位与 x 相同
      value = pc + imm32; // pc 在 `relocateInstructionInThumb(target_addr - 1, ... ` 时做过处理, 也是偶数
      trampoline_instructions[idx++] = instruction & 0xFF00;
      trampoline_instructions[idx++] = 0xE003;  // B PC, #6
    }
...
trampoline_instructions[idx++] = 0xF8DF;
trampoline_instructions[idx++] = 0xF000;  // LDR.W PC, [PC]
trampoline_instructions[idx++] = value & 0xFFFF;
trampoline_instructions[idx++] = value >> 16;
```