### PR TITLE
修复 relocate DMB.W 指令

### DIFF
--- a/relocate.c
+++ b/relocate.c
@@ -103,6 +103,11 @@ static int getTypeInThumb16(uint16_t instruction)
 
 static int getTypeInThumb32(uint32_t instruction)
 {
+	if ((instruction & 0xFFF0D000) == 0xF3B08000){
+		// `special control operations`(eg: `DMB.W ISH`)
+		// must be placed before `if ((instruction & 0xF800D000) == 0xF0008000)`
+		return UNDEFINE;
+	}
 	if ((instruction & 0xF800D000) == 0xF000C000) {
 		return BLX_THUMB32;
 	}


### PR DESCRIPTION
修复了 `DMB.W` 指令会被误判为 `B1_THUMB32` 导致崩溃的问题